### PR TITLE
add unix datagram socket support

### DIFF
--- a/client.go
+++ b/client.go
@@ -68,6 +68,7 @@ type transport struct {
 func NewClient(addr string, options ...Option) *Client {
 	opts := ClientOptions{
 		Addr:              addr,
+		AddrNetwork:       DefaultNetwork,
 		MetricPrefix:      DefaultMetricPrefix,
 		MaxPacketSize:     DefaultMaxPacketSize,
 		FlushInterval:     DefaultFlushInterval,
@@ -106,7 +107,7 @@ func NewClient(addr string, options ...Option) *Client {
 
 	for i := 0; i < opts.SendLoopCount; i++ {
 		c.trans.shutdownWg.Add(1)
-		go c.trans.sendLoop(opts.Addr, opts.ReconnectInterval, opts.RetryTimeout, opts.Logger)
+		go c.trans.sendLoop(opts.Addr, opts.AddrNetwork, opts.ReconnectInterval, opts.RetryTimeout, opts.Logger)
 	}
 
 	if opts.ReportInterval > 0 {

--- a/loops.go
+++ b/loops.go
@@ -63,7 +63,7 @@ func (t *transport) flushLoop(flushInterval time.Duration) {
 }
 
 // sendLoop handles packet delivery over UDP and periodic reconnects
-func (t *transport) sendLoop(addr string, reconnectInterval, retryTimeout time.Duration, log SomeLogger) {
+func (t *transport) sendLoop(addr string, network string, reconnectInterval, retryTimeout time.Duration, log SomeLogger) {
 	var (
 		sock       net.Conn
 		err        error
@@ -94,7 +94,7 @@ RECONNECT:
 		}()
 
 		var d net.Dialer
-		return d.DialContext(ctx, "udp", addr)
+		return d.DialContext(ctx, network, addr)
 	}()
 
 	if err != nil {

--- a/options.go
+++ b/options.go
@@ -40,6 +40,7 @@ const (
 	DefaultBufPoolCapacity   = 20
 	DefaultSendQueueCapacity = 10
 	DefaultSendLoopCount     = 1
+	DefaultNetwork           = "udp"
 )
 
 // SomeLogger defines logging interface that allows using 3rd party loggers
@@ -52,6 +53,9 @@ type SomeLogger interface {
 type ClientOptions struct {
 	// Addr is statsd server address in "host:port" format
 	Addr string
+
+	// AddrNetwork is network type for the address. Defaults to udp.
+	AddrNetwork string
 
 	// MetricPrefix is metricPrefix to prepend to every metric being sent
 	//
@@ -259,5 +263,12 @@ func TagStyle(style *TagFormat) Option {
 func DefaultTags(tags ...Tag) Option {
 	return func(c *ClientOptions) {
 		c.DefaultTags = tags
+	}
+}
+
+// Network sets the network to use Dialing the statsd server
+func Network(network string) Option {
+	return func(c *ClientOptions) {
+		c.AddrNetwork = network
 	}
 }


### PR DESCRIPTION
This change allows setting the network when calling Dial. 

```
BenchmarkSimple-12                      7542826               153.4 ns/op
BenchmarkSimpleUnixSocket-12             8710803               136.6 ns/op
BenchmarkComplexDelivery-12              5909164               203.0 ns/op
BenchmarkTagged-12                       2795354               418.0 ns/op
PASS
ok      github.com/smira/go-statsd      9.830s

```
 
eg https://github.com/stripe/veneur can be configured to listen over unixgram socket instead of udp.